### PR TITLE
Remove wf_xtra_var_ from WiredBoxType mapping

### DIFF
--- a/src/main/java/me/roboroads/robosort/data/WiredFurni.java
+++ b/src/main/java/me/roboroads/robosort/data/WiredFurni.java
@@ -16,6 +16,7 @@ public class WiredFurni {
         put("wf_xtra_filter_", WiredBoxType.FILTER);
         put("wf_cnd_", WiredBoxType.CONDITION);
         put("wf_xtra_", WiredBoxType.ADDON);
+        remove("wf_xtra_var_");
         put("wf_act_", WiredBoxType.EFFECT);
     }};
 


### PR DESCRIPTION
Removed 'wf_xtra_var_' from WiredBoxType mapping.
Because these go on top off a variable box so dont need sorting.